### PR TITLE
Renew config and move deprecated command

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -129,10 +129,7 @@ alias ll="ls -la --color"
 alias ~="cd ~"
 alias ..="cd .."
 
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-export PATH=$PATH:$JAVA_HOME/bin
-export HADOOP_HOME=/usr/local/hadoop-2.8.5
-export PATH=$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin
+export PATH=/opt/homebrew/bin:$PATH
 
 autoload -Uz compinit
 compinit

--- a/.zshrc
+++ b/.zshrc
@@ -133,4 +133,5 @@ export PATH=/opt/homebrew/bin:$PATH
 
 autoload -Uz compinit
 compinit
+(( ! ${+functions[p10k]} )) || p10k finalize
 # End of lines added by compinstall

--- a/.zshrc
+++ b/.zshrc
@@ -123,7 +123,6 @@ zstyle ':completion:*' completer _complete _ignored _approximate
 zstyle ':completion:*' max-errors 3
 zstyle :compinstall filename '/Users/james/.zshrc'
 
-alias cat="ccat $*"
 alias c="clear"
 alias ls="ls --color"
 alias ll="ls -la --color"

--- a/.zshrc
+++ b/.zshrc
@@ -13,6 +13,9 @@ source ~/.zplug/init.zsh
 # Initialize profile
 source ~/.profile
 
+# Auto-complete kubectl
+source <(kubectl completion zsh)
+
 # Make sure to use double quotes
 zplug "zsh-users/zsh-history-substring-search"
 


### PR DESCRIPTION
# Description
Current ```.zshrc``` is too old to use. And it contains many deprecated commands and redundant settings.
For better environment setting management, we should

1. Add modern setting, e.g. k8s auto-complete
2. Remove deprecated commands, e.g. ccat
3. Remove redundant settings, e.g. hadoop path setting

# Summary of Changes

- [x] Add k8s auto-complete
- [x] Remove ccat
- [x] Remove redundant path setting
- [x] Add p10k finalize command

# How to test
TBD
# Merge checklist
- [x] Test in local
- [x] Test in feature env